### PR TITLE
feat: adiciona comando !metal-espadinha

### DIFF
--- a/controllers/commands_test.go
+++ b/controllers/commands_test.go
@@ -101,6 +101,10 @@ func TestGetMessageByCommand(t *testing.T) {
 			"Playlist Metal: https://open.spotify.com/playlist/2EyQ31SxCDDEdn2sRrMGQX?si=2qJpNrnTRW6dyhmiSLiiTg",
 		},
 		{
+			"metal-espadinha",
+			"Playlist Metal: https://open.spotify.com/playlist/2EyQ31SxCDDEdn2sRrMGQX?si=2qJpNrnTRW6dyhmiSLiiTg",
+		},
+		{
 			"news",
 			"Se inscreva na nossa newsletter: https://teomewhy.substack.com",
 		},

--- a/controllers/fixtures.go
+++ b/controllers/fixtures.go
@@ -111,6 +111,11 @@ var mensagens = []repositories.Messagem{
 	},
 
 	{
+		Chave:    "metal-espadinha",
+		Conteudo: "Playlist Metal: https://open.spotify.com/playlist/2EyQ31SxCDDEdn2sRrMGQX?si=2qJpNrnTRW6dyhmiSLiiTg",
+	},
+
+	{
 		Chave:    "news",
 		Conteudo: "Se inscreva na nossa newsletter: https://teomewhy.substack.com",
 	},


### PR DESCRIPTION
## Resumo

Adiciona o comando `!metal-espadinha` como alias para a mesma playlist do `!metal` já existente.

- `controllers/fixtures.go`: nova entrada `metal-espadinha` na lista `mensagens`, mesmo conteúdo (URL da playlist) do `metal`.
- `controllers/commands_test.go`: caso de teste espelhando o padrão já usado para `metal`.

Não precisou mexer no dispatcher (`GetCommand` em `commands.go`) — comandos fora da lista de casos especiais (`join`, `cubos`, `presente`, `troca`, `fiel`) já caem no lookup genérico via `messageService.GetMensagem`, então bastou registrar a chave nova.

## Test plan

- `gofmt -l controllers/fixtures.go controllers/commands_test.go` → limpo
- `go vet ./...` → sem issues
- `go test ./controllers/... -run "TestGetMessageByCommand/metal" -v` → `metal` e `metal-espadinha` passando
- Rodei a suíte completa (`make test`) e `go test` por pacote: as falhas pré-existentes em `repositories` (`TestLoyalCreateUser`, `TestLoyalAddPoints`) e `services` (`TestCreateNewUser`) dependem de um serviço externo em `localhost:8081` não disponível neste ambiente; os 5 casos falhando em `TestGetMessageByCommand` (agenda/amazon/loja/pix/projeto) já divergiam do fixture antes desta mudança — nenhum relacionado a esta PR.
- Não há workflow de CI configurado no repo (sem `.github/workflows`), então validei manualmente com os comandos acima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)